### PR TITLE
Add C example to main repo (#701)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,0 +1,27 @@
+// +build ignore
+
+#include <stdio.h>
+#include <stdlib.h>
+#define WEBVIEW_HEADER
+#include "webview.h"
+
+void myFunc(const char *seq, const char *req, void *arg) {
+	printf("Params: %s\n", req);
+}
+
+#ifdef WIN32
+int WINAPI WinMain(HINSTANCE hInt, HINSTANCE hPrevInst, LPSTR lpCmdLine,
+                   int nCmdShow) {
+#else
+int main() {
+#endif
+	webview_t w = webview_create(0, NULL);
+	webview_set_title(w, "Webview Example");
+	webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
+	webview_bind(w, "myFunc", myFunc, NULL);
+	webview_navigate(w, "data:text/html, <button onclick='myFunc(\"Foo bar\")'>Click Me</button>");
+	webview_run(w);
+	webview_destroy(w);
+	return 0;
+}
+

--- a/script/build.sh
+++ b/script/build.sh
@@ -28,8 +28,13 @@ else
 	echo "SKIP: Linting (clang-tidy not installed)"
 fi
 
-echo "Building example"
+echo "Building C++ example"
 c++ main.cc $FLAGS -o webview
+
+echo "Building C example"
+c++ -c $FLAGS webview.cc -o webview.o
+cc -c main.c -o main.o
+c++ main.o webview.o $FLAGS -o webview-example
 
 echo "Building test app"
 c++ webview_test.cc $FLAGS -o webview_test


### PR DESCRIPTION
* Add C example to main repo

This adds the C example found at webview/webview_c to the main
repository, and configures the Unix build scripts to test it in CI.
This will ensure that the C example is constantly tested as well as
the C++ one.

It currently does not add the C example to the Windows tests. That
can either be added to this PR or separately if desired.

* Use cc and c++ instead of gcc and g++